### PR TITLE
feat(posts): add PostsEntity with lifecycle hooks

### DIFF
--- a/src/main/java/dev/joshuahale/backend/posts/PostsEntity.java
+++ b/src/main/java/dev/joshuahale/backend/posts/PostsEntity.java
@@ -1,0 +1,91 @@
+package dev.joshuahale.backend.posts;
+
+import  jakarta.persistence.*;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "posts")
+public class PostsEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, unique = true, length = 200)
+    private String slug;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String content;
+
+    @Column(name = "hero_image", length = 500)
+    private String heroImage;
+
+    @Column(name = "created_at", nullable = false, columnDefinition = "timestamptz")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false, columnDefinition = "timestamptz")
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = OffsetDateTime.now();
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public String getHeroImage() {
+        return heroImage;
+    }
+
+    public void setHeroImage(String heroImage) {
+        this.heroImage = heroImage;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}
+
+
+
+
+


### PR DESCRIPTION
## What
- Added PostsEntity class
- Includes PrePersist/PreUpdate lifecycle hooks for timestamps
- Maps SQL table columns to entity fields

## Why
- Start backend data model for blog posts